### PR TITLE
feat(smItems, smProxy): Add SQL Connectivity for Items and ban system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # smPl
-Stahlmetall plugins is a collection of Paper plugins for a WIP server
+Stahlmetall plugins is a collection of Paper and Velocity plugins for a WIP server
 
 ## Building
 Note: These plugins are not intended for private use.
@@ -10,6 +10,10 @@ To compile, run the following command in the root folder
 ```
 
 You can then copy the compiled Jar from its respective subfolders in /build/libs into your servers plugins folder.
+WARNING: For the Velocity plugin, copy the jar with the -all suffix, or it will not work!
+
+## Setup Guide
+Coming Soon™
 
 ## License
 - Copyright (C) 2022 ixhbinphoenix

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Coming Soon™
 - Copyright (C) 2022 ixhbinphoenix
 - Copyright (C) 2022 renkertm
 
-This Project is licensed under the GNU General Public License v3.0 which you can read [here](./LICENSE) or at [https://gnu.org/licenses](https://gnu.org/licenses)
+This Project is, unless mentioned otherwise, licensed under the GNU General Public License v3.0 which you can read [here](./LICENSE) or at [https://gnu.org/licenses](https://gnu.org/licenses)

--- a/smItems/build.gradle.kts
+++ b/smItems/build.gradle.kts
@@ -24,6 +24,12 @@ dependencies {
     compileOnly(project(":smChat"))
     compileOnly(project(":smEntities"))
 
+    implementation("org.jetbrains.exposed:exposed-core:0.38.1")
+    implementation("org.jetbrains.exposed:exposed-dao:0.38.1")
+    implementation("org.jetbrains.exposed:exposed-jdbc:0.38.1")
+    implementation("org.jetbrains.exposed:exposed-java-time:0.38.1")
+    implementation("org.postgresql:postgresql:42.3.3")
+
     implementation(kotlin("stdlib"))
 }
 

--- a/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/Main.kt
+++ b/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/Main.kt
@@ -4,15 +4,22 @@ import me.ixhbinphoenix.smPl.smCore.commands.BaseCommand
 import me.ixhbinphoenix.smPl.smItems.commands.giveItemCommand
 import me.ixhbinphoenix.smPl.smItems.commands.metaCommand
 import me.ixhbinphoenix.smPl.smItems.commands.setItemXPCommand
+import me.ixhbinphoenix.smPl.smItems.db.EquipmentUtils
 import me.ixhbinphoenix.smPl.smItems.events.Events
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.plugin.java.JavaPlugin
+import org.jetbrains.exposed.sql.Database
 
 @Suppress("unused")
 class Main : JavaPlugin() {
+    val dbConnection: Database
     init {
         instance = this
+        config.options().copyDefaults(true)
+        saveDefaultConfig()
+        dbConnection = Database.connect(config.getString("db.jdbcConnectionString")!!, driver = "org.postgresql.Driver", user = config.getString("db.user")!!, password = config.getString("db.password")!!)
+        EquipmentUtils.setupDB()
     }
 
     override fun onEnable() {

--- a/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/commands/giveItemCommand.kt
+++ b/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/commands/giveItemCommand.kt
@@ -1,111 +1,42 @@
 package me.ixhbinphoenix.smPl.smItems.commands
 
 import me.ixhbinphoenix.smPl.smCore.commands.BaseCommand
-import me.ixhbinphoenix.smPl.smItems.*
+import me.ixhbinphoenix.smPl.smItems.db.EquipmentItem
+import me.ixhbinphoenix.smPl.smItems.db.EquipmentUtils
 import me.ixhbinphoenix.smPl.smItems.item.ItemUtils
-import me.ixhbinphoenix.smPl.smItems.item.SetBonus
+import me.ixhbinphoenix.smPl.smItems.item.sets.SetHelper
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
-import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Color
-import org.bukkit.Material
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.bukkit.inventory.meta.LeatherArmorMeta
-import kotlin.collections.ArrayList
 
 class giveItemCommand : BaseCommand {
   private val itemUtils = ItemUtils()
+  private val setHelper = SetHelper()
 
   override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
     if (sender is Player) {
-      when {
-        args[0] == "satans_teachings" -> {
-          val item = itemUtils.createWeapon(Material.BOOK, "Satan's teachings", "satans_teachings", Rarity.LEGENDARY, WeaponTypes.BOOK, 666, 420, null)
+      if (args.isNotEmpty()) {
+        if (EquipmentUtils.getItem(args[0]) is EquipmentItem) {
+          val dbItem = EquipmentUtils.getItem(args[0])!!
+          val set = setHelper.setObjects[dbItem.set]
+          val stats = hashMapOf(
+            "damage" to dbItem.damage,
+            "mana" to dbItem.mana,
+            "max_health" to dbItem.max_health,
+            "defence" to dbItem.defence
+          )
+          val item = itemUtils.createEquipment(dbItem.material, dbItem.display_name, dbItem.string_id, dbItem.rarity, dbItem.item_type, stats, set)
+          if (dbItem.rgb is Int) {
+            val im = item.itemMeta
+            (im as LeatherArmorMeta).setColor(Color.fromRGB(dbItem.rgb!!))
+            item.itemMeta = im
+          }
           itemUtils.giveItem(item, sender)
-        }
-        args[0] == "programmers_cat_ears" -> {
-          val set = SetBonus
-          set.bonusName = "Programmer"
-          set.set = "PROGRAMMER"
-
-          val setLore = ArrayList<Component>()
-          setLore.add(Component.text("The ultimate outfit for a Programmer").color(NamedTextColor.DARK_GRAY))
-          set.setLore = setLore
-
-          val effect = ArrayList<Component>()
-          effect.add(Component.text("Gain 10,000 Mana").color(NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false))
-          set.setEffect = effect
-
-          val item = itemUtils.createArmor(Material.LEATHER_HELMET, "Programmer's Cat ears", "programmers_cat_ears", Rarity.MYTHIC, ArmorTypes.HELMET, 1000, 1000, set)
-          val im = item.itemMeta as LeatherArmorMeta
-          im.setColor(Color.FUCHSIA)
-          im.isUnbreakable = true
-          item.itemMeta = im
-          itemUtils.giveItem(item, sender)
-        }
-        args[0] == "programmers_croptop" -> {
-          val set = SetBonus
-          set.bonusName = "Programmer"
-          set.set = "PROGRAMMER"
-
-          val setLore = ArrayList<Component>()
-          setLore.add(Component.text("The ultimate outfit for a Programmer").color(NamedTextColor.DARK_GRAY))
-          set.setLore = setLore
-
-          val effect = ArrayList<Component>()
-          effect.add(Component.text("Gain 10,000 Mana").color(NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false))
-          set.setEffect = effect
-
-          val item = itemUtils.createArmor(Material.LEATHER_CHESTPLATE, "Programmer's Crop-top", "programmers_crop_top", Rarity.MYTHIC, ArmorTypes.CHESTPLATE, 1000, 1000, set)
-          val im = item.itemMeta as LeatherArmorMeta
-          im.setColor(Color.FUCHSIA)
-          im.isUnbreakable = true
-          item.itemMeta = im
-          itemUtils.giveItem(item, sender)
-        }
-        args[0] == "programmers_skirt" -> {
-          val set = SetBonus
-          set.bonusName = "Programmer"
-          set.set = "PROGRAMMER"
-
-          val setLore = ArrayList<Component>()
-          setLore.add(Component.text("The ultimate outfit for a Programmer").color(NamedTextColor.DARK_GRAY))
-          set.setLore = setLore
-
-          val effect = ArrayList<Component>()
-          effect.add(Component.text("Gain 10,000 Mana").color(NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false))
-          set.setEffect = effect
-
-          val item = itemUtils.createArmor(Material.LEATHER_LEGGINGS, "Programmer's Skirt", "programmers_skirt", Rarity.MYTHIC, ArmorTypes.LEGGINGS, 1000, 1000, set)
-          val im = item.itemMeta as LeatherArmorMeta
-          im.setColor(Color.FUCHSIA)
-          im.isUnbreakable = true
-          item.itemMeta = im
-          itemUtils.giveItem(item, sender)
-        }
-        args[0] == "programmers_thigh_highs" -> {
-          val set = SetBonus
-          set.bonusName = "Programmer"
-          set.set = "PROGRAMMER"
-
-          val setLore = ArrayList<Component>()
-          setLore.add(Component.text("The ultimate outfit for a Programmer").color(NamedTextColor.DARK_GRAY))
-          set.setLore = setLore
-
-          val effect = ArrayList<Component>()
-          effect.add(Component.text("Gain 10,000 Mana").color(NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false))
-          set.setEffect = effect
-
-          val item = itemUtils.createArmor(Material.LEATHER_BOOTS, "Programmer's Thigh-highs", "programmers_thigh_highs", Rarity.MYTHIC, ArmorTypes.BOOTS, 1000, 1000, set)
-          val im = item.itemMeta as LeatherArmorMeta
-          im.setColor(Color.FUCHSIA)
-          im.isUnbreakable = true
-          item.itemMeta = im
-          itemUtils.giveItem(item, sender)
-        }
-        else -> {
+        } else {
           sender.sendMessage(Component.text("Unknown Item!").color(NamedTextColor.RED))
         }
       }
@@ -115,13 +46,7 @@ class giveItemCommand : BaseCommand {
 
   override fun onTabComplete(sender: CommandSender, command: Command, label: String, args: Array<out String>): MutableList<String>? {
     if (args.size == 1) {
-      return arrayListOf(
-        "satans_teachings",
-        "programmers_cat_ears",
-        "programmers_croptop",
-        "programmers_skirt",
-        "programmers_thigh_highs"
-      )
+      return EquipmentUtils.getRecomms(args[0])
     }
     return null
   }

--- a/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/db/EquipmentItems.kt
+++ b/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/db/EquipmentItems.kt
@@ -1,0 +1,110 @@
+package me.ixhbinphoenix.smPl.smItems.db
+
+import me.ixhbinphoenix.smPl.smItems.Rarity
+import me.ixhbinphoenix.smPl.smItems.Types
+import me.ixhbinphoenix.smPl.smItems.getInstance
+import org.bukkit.Material
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.postgresql.util.PGobject
+
+class PGEnum<T: Enum<T>>(enumTypeName: String, enumValue: T?): PGobject() {
+  init {
+    value = enumValue?.name
+    type = enumTypeName
+  }
+}
+
+private inline fun <reified T : Enum<T>> getEnumQuery(dbName: String): String {
+  val names = enumValues<T>().map { it.name }
+  var str = "CREATE TYPE $dbName AS ENUM ("
+  for (name in names) {
+    str += "'$name'"
+    if (names.indexOf(name) != names.size - 1) {
+      str += ", "
+    }
+  }
+  str += ");"
+  return str
+}
+
+object EquipmentItems : IntIdTable() {
+  val string_id = text("string_id").uniqueIndex()
+  val display_name = text("display_name")
+  val material = customEnumeration("material", "MaterialEnum", { value -> Material.valueOf(value as String) }, { PGEnum("MaterialEnum", it) })
+  val rarity = customEnumeration("rarity", "RarityEnum", {value -> Rarity.valueOf(value as String) }, { PGEnum("RarityEnum", it) })
+  val item_type = customEnumeration("item_type", "TypeEnum", { value -> Types.valueOf(value as String) }, { PGEnum("TypeEnum", it) })
+  val set = text("set")
+  val rgb = integer("rgb").nullable()
+  val defence = integer("defence").default(0)
+  val max_health = integer("max_health").default(0)
+  val damage = integer("damage").default(0)
+  val mana = integer("mana").default(0)
+}
+
+class EquipmentItem(id: EntityID<Int>): IntEntity(id) {
+  companion object : IntEntityClass<EquipmentItem>(EquipmentItems)
+  var string_id by EquipmentItems.string_id
+  var display_name by EquipmentItems.display_name
+  var material by EquipmentItems.material
+  var rarity by EquipmentItems.rarity
+  var item_type by EquipmentItems.item_type
+  var set by EquipmentItems.set
+  var rgb by EquipmentItems.rgb
+  var defence by EquipmentItems.defence
+  var max_health by EquipmentItems.max_health
+  var damage by EquipmentItems.damage
+  var mana by EquipmentItems.mana
+}
+
+class EquipmentUtils {
+  companion object {
+    fun setupDB() {
+      val db = getInstance().dbConnection
+
+      transaction (db) {
+        SchemaUtils.create(EquipmentItems)
+      }
+    }
+
+    fun getItem(stringID: String): EquipmentItem? {
+      val db = getInstance().dbConnection
+
+      return transaction (db) {
+        val item = EquipmentItem.find { EquipmentItems.string_id eq stringID }
+
+        try {
+          return@transaction item.toList()[0]
+        } catch (e: NoSuchElementException) {
+          return@transaction null
+        }
+      }
+    }
+
+    fun getItem(ID: Int): EquipmentItem? {
+      val db = getInstance().dbConnection
+
+      return transaction (db) {
+        val item = EquipmentItem.find { EquipmentItems.id eq ID }
+
+        try {
+          return@transaction item.toList()[0]
+        } catch (e: NoSuchElementException) {
+          return@transaction null
+        }
+      }
+    }
+
+    fun getRecomms(startsWith: String): MutableList<String> {
+      val db = getInstance().dbConnection
+
+      return transaction(db) {
+        return@transaction EquipmentItem.find { EquipmentItems.string_id like "${startsWith}%" }.map { it.string_id }.toMutableList()
+      }
+    }
+  }
+}

--- a/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/item/ItemUtils.kt
+++ b/smItems/src/main/kotlin/me/ixhbinphoenix/smPl/smItems/item/ItemUtils.kt
@@ -7,16 +7,18 @@ import me.ixhbinphoenix.smPl.smItems.events.StatsCalculation
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
+import java.util.UUID
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.persistence.PersistentDataType
 import org.bukkit.scheduler.BukkitRunnable
-import java.util.*
 import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
 import kotlin.math.roundToInt
 import kotlin.math.floor
 import kotlin.math.pow
@@ -53,54 +55,28 @@ class ItemUtils {
     StatsCalculation(player).runTaskLater(plugin, 2)
   }
 
-  fun createWeapon(mat: Material, name: String, id: String, rarity: Rarity, weaponType: WeaponTypes, dmg: Int, mana: Int = 0, set: SetBonus?): ItemStack {
+  fun createEquipment(mat: Material, name: String, id: String, rarity: Rarity, Type: Types, stats: HashMap<String, Int>, set: SetBonus?): ItemStack {
     val item = ItemStack(mat, 1)
-    val im = item.itemMeta
+    val im = setStats(stats, item.itemMeta)
     im.isUnbreakable = true
     im.displayName(Component.text(name).color(RarityColor.valueOf(rarity.name).color).decoration(TextDecoration.ITALIC, false))
-    val statTexts = ArrayList<Component>()
-    statTexts.add(createStatText("Damage", dmg.toString(), NamedTextColor.RED, false).decoration(TextDecoration.ITALIC, false))
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:equipment.damage.int")!!, PersistentDataType.INTEGER, dmg)
-    if (mana > 0) {
-      statTexts.add(createStatText("Mana", mana.toString(), NamedTextColor.AQUA, false).decoration(TextDecoration.ITALIC, false))
-      im.persistentDataContainer.set(NamespacedKey.fromString("smitems:equipment.mana.int")!!, PersistentDataType.INTEGER, mana)
-    }
+    val statText = genStatTexts(stats)
     im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.rarity.str")!!, PersistentDataType.STRING, rarity.name)
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.type.str")!!, PersistentDataType.STRING, ItemCategories.WEAPON.name)
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:weapon.type.str")!!, PersistentDataType.STRING, weaponType.name)
+    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.type.str")!!, PersistentDataType.STRING, Type.category.name)
+    when (Type.category) {
+      ItemCategories.WEAPON -> {
+        im.persistentDataContainer.set(NamespacedKey.fromString("smitems:weapon.type.str")!!, PersistentDataType.STRING, Type.name)
+      }
+      ItemCategories.ARMOR -> {
+        im.persistentDataContainer.set(NamespacedKey.fromString("smitems:armor.type.str")!!, PersistentDataType.STRING, Type.name)
+      }
+      ItemCategories.ACCESSORY -> {
+        im.persistentDataContainer.set(NamespacedKey.fromString("smitems:accessory.type.str")!!, PersistentDataType.STRING, Type.name)
+      }
+    }
     im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.id.str")!!, PersistentDataType.STRING, id)
     im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.uuid.str")!!, PersistentDataType.STRING, UUID.randomUUID().toString())
-    im.lore(genLore(rarity, Types.valueOf(weaponType.name), statTexts, 0, 0, set))
-    im.addItemFlags(ItemFlag.HIDE_ATTRIBUTES)
-    im.addItemFlags(ItemFlag.HIDE_UNBREAKABLE)
-    im.addItemFlags(ItemFlag.HIDE_DYE)
-    item.itemMeta = im
-    return item
-  }
-
-  fun createArmor(mat: Material, name: String, id: String, rarity: Rarity, armorType: ArmorTypes, defence: Int = 0, maxHealth: Int = 0, set: SetBonus?): ItemStack {
-    val item = ItemStack(mat, 1)
-    val im = item.itemMeta
-    im.isUnbreakable = true
-    im.displayName(Component.text(name).color(RarityColor.valueOf(rarity.name).color).decoration(TextDecoration.ITALIC, false))
-    val statTexts = ArrayList<Component>()
-    if (defence > 0) {
-      statTexts.add(createStatText("Defence", defence.toString(), NamedTextColor.GREEN, false).decoration(TextDecoration.ITALIC, false))
-      im.persistentDataContainer.set(NamespacedKey.fromString("smitems:equipment.defence.int")!!, PersistentDataType.INTEGER, defence)
-    }
-    if (maxHealth > 0) {
-      statTexts.add(createStatText("Max Health", maxHealth.toString(), NamedTextColor.RED, false).decoration(TextDecoration.ITALIC, false))
-      im.persistentDataContainer.set(NamespacedKey.fromString("smitems:equipment.maxhealth.int")!!, PersistentDataType.INTEGER, maxHealth)
-    }
-    if (set is SetBonus) {
-      im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.set.str")!!, PersistentDataType.STRING, set.set)
-    }
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.rarity.str")!!, PersistentDataType.STRING, rarity.name)
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.type.str")!!, PersistentDataType.STRING, ItemCategories.ARMOR.name)
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:armor.type.str")!!, PersistentDataType.STRING, armorType.name)
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.id.str")!!, PersistentDataType.STRING, id)
-    im.persistentDataContainer.set(NamespacedKey.fromString("smitems:item.uuid.str")!!, PersistentDataType.STRING, UUID.randomUUID().toString())
-    im.lore(genLore(rarity, Types.valueOf(armorType.name), statTexts, 0, 0, set))
+    im.lore(genLore(rarity, Type, statText, 0, 0, set))
     im.addItemFlags(ItemFlag.HIDE_ATTRIBUTES)
     im.addItemFlags(ItemFlag.HIDE_UNBREAKABLE)
     im.addItemFlags(ItemFlag.HIDE_DYE)
@@ -145,6 +121,45 @@ class ItemUtils {
     }
     lore.add(Component.text("${rarity.name} ${type.name}").color(RarityColor.valueOf(rarity.name).color).decoration(TextDecoration.ITALIC, false))
     return lore
+  }
+
+  fun genStatTexts(stats: HashMap<String, Int>): ArrayList<Component> {
+    val statTexts = ArrayList<Component>()
+    for (stat in stats) {
+      when (stat.key) {
+        "damage" -> {
+          if (stat.value > 0) {
+            statTexts.add(createStatText("Damage", stat.value.toString(), NamedTextColor.RED, false).decoration(TextDecoration.ITALIC, false))
+          }
+        }
+        "mana" -> {
+          if (stat.value > 0) {
+            statTexts.add(createStatText("Mana", stat.value.toString(), NamedTextColor.AQUA, false).decoration(TextDecoration.ITALIC, false))
+          }
+        }
+        "defence" -> {
+          if (stat.value > 0) {
+            statTexts.add(createStatText("Defence", stat.value.toString(), NamedTextColor.GREEN, false).decoration(TextDecoration.ITALIC, false))
+          }
+        }
+        "max_health" -> {
+          if (stat.value > 0) {
+            statTexts.add(createStatText("Max Health", stat.value.toString(), NamedTextColor.RED, false).decoration(TextDecoration.ITALIC, false))
+          }
+        }
+      }
+    }
+    return statTexts
+  }
+
+  fun setStats(stats: HashMap<String, Int>, meta: ItemMeta): ItemMeta {
+    for (stat in stats) {
+      if (stat.value > 0) {
+        val key = "smitems:equipment.${stat.key}.int".replace("_", "")
+        meta.persistentDataContainer.set(NamespacedKey.fromString(key)!!, PersistentDataType.INTEGER, stat.value)
+      }
+    }
+    return meta
   }
 
   fun getRarityMultiplier(rarity: Rarity): Int {

--- a/smItems/src/main/resources/config.yml
+++ b/smItems/src/main/resources/config.yml
@@ -1,0 +1,4 @@
+db:
+  jdbcConnectionString: "jdbc:postgresql://localhost:5432/minecraft"
+  user: "root"
+  password: "root"

--- a/smProxy/build.gradle.kts
+++ b/smProxy/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     kotlin("jvm") version "1.6.20"
     kotlin("kapt")
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.6.20"
     java
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
@@ -20,6 +21,13 @@ dependencies {
     implementation("com.velocitypowered:velocity-api:3.1.0")
     kapt("com.velocitypowered:velocity-api:3.1.0")
 
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+    implementation("org.jetbrains.exposed:exposed-core:0.38.1")
+    implementation("org.jetbrains.exposed:exposed-dao:0.38.1")
+    implementation("org.jetbrains.exposed:exposed-jdbc:0.38.1")
+    implementation("org.jetbrains.exposed:exposed-java-time:0.38.1")
+    implementation("org.postgresql:postgresql:42.3.3")
+
     implementation(kotlin("stdlib"))
 }
 
@@ -34,6 +42,10 @@ tasks {
     build {
         dependsOn(shadowJar)
     }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }
 
 tasks.getByName<Test>("test") {

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/BaseCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/BaseCommand.kt
@@ -1,0 +1,6 @@
+package me.ixhbinphoenix.smPl.smProxy.commands
+
+import com.velocitypowered.api.command.SimpleCommand
+
+interface BaseCommand : SimpleCommand {
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/banCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/banCommand.kt
@@ -4,15 +4,18 @@ import com.velocitypowered.api.command.SimpleCommand
 import com.velocitypowered.api.proxy.Player
 import me.ixhbinphoenix.smPl.smProxy.db.BanUtils
 import me.ixhbinphoenix.smPl.smProxy.getInstance
+import me.ixhbinphoenix.smPl.smProxy.utils.TimeUtils
+import me.ixhbinphoenix.smPl.smProxy.utils.getPermanentBanMessage
+import me.ixhbinphoenix.smPl.smProxy.utils.getTemporaryBanMessage
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
+import java.time.Instant
 import java.util.*
 
 class banCommand : BaseCommand {
     private val instance = getInstance()
 
-    // Only for permanent bans!
-    // /ban <player> <reason>
+    // /ban <player> [<time>] <reason>
     override fun execute(invocation: SimpleCommand.Invocation?) {
         if (invocation is SimpleCommand.Invocation) {
             val source = invocation.source()
@@ -21,21 +24,39 @@ class banCommand : BaseCommand {
                 if (args.size >= 2) {
                     val uuid = instance.uuidCache.getUUIDIfExists(args[0])
                     if (uuid is UUID) {
-                        val reason = args.drop(1).joinToString(" ")
-                        val id = BanUtils.createBan(uuid, source, true, reason, null)
-                        for (player in instance.server.allPlayers) {
-                            if (player.uniqueId == uuid) {
-                                player.disconnect(
-                                    Component.text("You have been permanently banned from the network!\n").color(NamedTextColor.RED)
-                                        .append(Component.text("Reason: ").color(NamedTextColor.RED)
-                                            .append(Component.text(reason).color(NamedTextColor.YELLOW))
-                                        )
-                                        .append(Component.text("\n"))
-                                        .append(Component.text("Ban ID: ").color(NamedTextColor.RED)
-                                            .append(Component.text("#$id").color(NamedTextColor.YELLOW))
-                                        )
-                                )
+                        val duration = TimeUtils.parseString(args[1])
+                        val reason: String
+                        val id: Int
+                        if (duration is Long) {
+                            reason = args.drop(2).joinToString(" ")
+                            id = BanUtils.createBan(uuid, source, false, reason, Instant.now().plusMillis(duration))
+                            for (player in instance.server.allPlayers) {
+                                if (player.uniqueId == uuid) {
+                                    player.disconnect(getTemporaryBanMessage(reason, id, duration))
+                                }
                             }
+                            source.sendMessage(Component.text("Banned ").color(NamedTextColor.GREEN)
+                                .append(Component.text(args[0]).color(NamedTextColor.YELLOW))
+                                .append(Component.text(" for ").color(NamedTextColor.GREEN))
+                                .append(Component.text(args[1]).color(NamedTextColor.YELLOW))
+                                .append(Component.text(" because of ").color(NamedTextColor.GREEN))
+                                .append(Component.text(reason).color(NamedTextColor.YELLOW))
+                            )
+                        } else {
+                            reason = args.drop(1).joinToString(" ")
+                            id = BanUtils.createBan(uuid, source, true, reason, null)
+                            for (player in instance.server.allPlayers) {
+                                if (player.uniqueId == uuid) {
+                                    player.disconnect(
+                                        getPermanentBanMessage(reason, id)
+                                    )
+                                }
+                            }
+                            source.sendMessage(Component.text("Banned ").color(NamedTextColor.GREEN)
+                                .append(Component.text(args[0]).color(NamedTextColor.YELLOW))
+                                .append(Component.text(" because of ").color(NamedTextColor.GREEN))
+                                .append(Component.text(reason).color(NamedTextColor.YELLOW))
+                            )
                         }
                     } else {
                         source.sendMessage(Component.text("Player does not exist!").color(NamedTextColor.RED))
@@ -59,7 +80,7 @@ class banCommand : BaseCommand {
     override fun suggest(invocation: SimpleCommand.Invocation?): MutableList<String> {
         if (invocation is SimpleCommand.Invocation) {
             val args = invocation.arguments()
-            if (args.size == 1) {
+            if (args.size <= 1) {
                 return instance.server.allPlayers.map { it.username }.toMutableList()
             }
         }

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/banCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/banCommand.kt
@@ -1,0 +1,68 @@
+package me.ixhbinphoenix.smPl.smProxy.commands
+
+import com.velocitypowered.api.command.SimpleCommand
+import com.velocitypowered.api.proxy.Player
+import me.ixhbinphoenix.smPl.smProxy.db.BanUtils
+import me.ixhbinphoenix.smPl.smProxy.getInstance
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import java.util.*
+
+class banCommand : BaseCommand {
+    private val instance = getInstance()
+
+    // Only for permanent bans!
+    // /ban <player> <reason>
+    override fun execute(invocation: SimpleCommand.Invocation?) {
+        if (invocation is SimpleCommand.Invocation) {
+            val source = invocation.source()
+            val args = invocation.arguments()
+            if (source is Player) {
+                if (args.size >= 2) {
+                    val uuid = instance.uuidCache.getUUIDIfExists(args[0])
+                    if (uuid is UUID) {
+                        val reason = args.drop(1).joinToString(" ")
+                        val id = BanUtils.createBan(uuid, source, true, reason, null)
+                        for (player in instance.server.allPlayers) {
+                            if (player.uniqueId == uuid) {
+                                player.disconnect(
+                                    Component.text("You have been permanently banned from the network!\n").color(NamedTextColor.RED)
+                                        .append(Component.text("Reason: ").color(NamedTextColor.RED)
+                                            .append(Component.text(reason).color(NamedTextColor.YELLOW))
+                                        )
+                                        .append(Component.text("\n"))
+                                        .append(Component.text("Ban ID: ").color(NamedTextColor.RED)
+                                            .append(Component.text("#$id").color(NamedTextColor.YELLOW))
+                                        )
+                                )
+                            }
+                        }
+                    } else {
+                        source.sendMessage(Component.text("Player does not exist!").color(NamedTextColor.RED))
+                    }
+                } else {
+                    source.sendMessage(Component.text("Not enough arguments!").color(NamedTextColor.RED))
+                }
+            } else {
+                source.sendMessage(Component.text("Banning from the console is not supported yet!").color(NamedTextColor.RED))
+            }
+        }
+    }
+
+    override fun hasPermission(invocation: SimpleCommand.Invocation?): Boolean {
+        if (invocation is SimpleCommand.Invocation) {
+            return invocation.source().hasPermission("smproxy.moderation.ban")
+        }
+        return false
+    }
+
+    override fun suggest(invocation: SimpleCommand.Invocation?): MutableList<String> {
+        if (invocation is SimpleCommand.Invocation) {
+            val args = invocation.arguments()
+            if (args.size == 1) {
+                return instance.server.allPlayers.map { it.username }.toMutableList()
+            }
+        }
+        return mutableListOf()
+    }
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/broadcastCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/broadcastCommand.kt
@@ -9,12 +9,8 @@ import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration
 
 @Suppress("classname")
-class broadcastCommand : SimpleCommand {
+class broadcastCommand : BaseCommand {
   private val instance = getInstance()
-
-  val meta: CommandMeta = instance.server.commandManager.metaBuilder("broadcast")
-    .aliases("bc")
-    .build()
 
   override fun execute(invocation: SimpleCommand.Invocation?) {
     if (invocation is SimpleCommand.Invocation) {

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/pingCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/pingCommand.kt
@@ -7,11 +7,8 @@ import me.ixhbinphoenix.smPl.smProxy.getInstance
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 
-class pingCommand : SimpleCommand {
+class pingCommand : BaseCommand {
   private val instance = getInstance()
-  
-  val meta: CommandMeta = instance.server.commandManager.metaBuilder("ping")
-    .build()
   
   override fun execute(invocation: SimpleCommand.Invocation?) {
     if (invocation is SimpleCommand.Invocation) {

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/scCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/scCommand.kt
@@ -10,10 +10,8 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 
 @Suppress("classname")
-class scCommand : SimpleCommand {
+class scCommand : BaseCommand {
   private val instance = getInstance()
-
-  val meta: CommandMeta = instance.server.commandManager.metaBuilder("sc").build()
 
   override fun execute(invocation: SimpleCommand.Invocation?) {
     if (invocation is SimpleCommand.Invocation) {

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/unbanCommand.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/commands/unbanCommand.kt
@@ -1,0 +1,63 @@
+package me.ixhbinphoenix.smPl.smProxy.commands
+
+import com.velocitypowered.api.command.SimpleCommand
+import me.ixhbinphoenix.smPl.smProxy.db.Ban
+import me.ixhbinphoenix.smPl.smProxy.db.BanUtils
+import me.ixhbinphoenix.smPl.smProxy.getInstance
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import java.util.UUID
+
+class unbanCommand : BaseCommand {
+    private val instance = getInstance()
+
+    // /unban <username | banID>
+    override fun execute(invocation: SimpleCommand.Invocation?) {
+        if (invocation is SimpleCommand.Invocation) {
+            val source = invocation.source()
+            val args = invocation.arguments()
+            if (args.isNotEmpty()) {
+                val uuid = instance.uuidCache.getUUIDIfExists(args[0])
+                if (uuid is UUID) {
+                    if (BanUtils.hasActiveBan(uuid)) {
+                        BanUtils.unBan(uuid)
+                        source.sendMessage(Component.text("Player has been unbanned!").color(NamedTextColor.GREEN))
+                    } else {
+                        source.sendMessage(Component.text("Player is not banned!").color(NamedTextColor.RED))
+                    }
+                } else {
+                    val banID = args[0].toIntOrNull()
+                    if (banID is Int) {
+                        if (BanUtils.getBan(banID) is Ban) {
+                            BanUtils.unBan(banID)
+                            source.sendMessage(Component.text("Player has been unbanned!").color(NamedTextColor.GREEN))
+                        } else {
+                            source.sendMessage(Component.text("Ban with ID $banID does not exist!").color(NamedTextColor.RED))
+                        }
+                    } else {
+                        source.sendMessage(Component.text("${args[0]} is not a valid Ban ID!").color(NamedTextColor.RED))
+                    }
+                }
+            } else {
+                source.sendMessage(Component.text("Not enough arguments!").color(NamedTextColor.RED))
+            }
+        }
+    }
+
+    override fun suggest(invocation: SimpleCommand.Invocation?): MutableList<String> {
+        if (invocation is SimpleCommand.Invocation) {
+            val args = invocation.arguments()
+            if (args.size == 1) {
+                return instance.server.allPlayers.map { it.username }.toMutableList()
+            }
+        }
+        return mutableListOf()
+    }
+
+    override fun hasPermission(invocation: SimpleCommand.Invocation?): Boolean {
+        if (invocation is SimpleCommand.Invocation) {
+            return invocation.source().hasPermission("smproxy.moderation.unban")
+        }
+        return false
+    }
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/db/Bans.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/db/Bans.kt
@@ -1,0 +1,147 @@
+package me.ixhbinphoenix.smPl.smProxy.db
+
+import com.velocitypowered.api.proxy.Player
+import me.ixhbinphoenix.smPl.smProxy.getInstance
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.javatime.timestamp
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.Instant
+import java.util.UUID
+
+object Bans: IntIdTable() {
+    val uuid: Column<String> = char("uuid", 36)
+    val moderator: Column<String> = char("moderator", 36)
+    val permanent = bool("permanent")
+    val expiry = timestamp("expiry").nullable()
+    val reason = text("reason").nullable()
+    val active = bool("active").default(true)
+}
+
+class Ban(id: EntityID<Int>): IntEntity(id) {
+    companion object : IntEntityClass<Ban>(Bans)
+    var uuid by Bans.uuid
+    var moderator by Bans.moderator
+    var permanent by Bans.permanent
+    var expiry by Bans.expiry
+    var reason by Bans.reason
+    var active by Bans.active
+}
+
+class BanUtils {
+    companion object {
+        fun createBan(player: UUID, moderatorPlayer: Player, isPermanent: Boolean, banReason: String?, banExpiry: Instant?): Int {
+            val db = getInstance().dbConnection
+            val playerUUID = player.toString()
+            val moderatorUUID = moderatorPlayer.uniqueId.toString()
+
+
+            val id = transaction (db) {
+
+                SchemaUtils.create(Bans)
+
+                return@transaction Ban.new {
+                    uuid = playerUUID
+                    moderator = moderatorUUID
+                    permanent = isPermanent
+                    reason = banReason
+                    expiry = banExpiry
+                    active = true
+                }.id.value
+            }
+            return id
+        }
+
+        fun getSeverestBan(bans: List<Ban>): Ban {
+            bans.forEach { ban ->
+                if (ban.permanent) {
+                    return ban
+                }
+            }
+            val highestExpiry = bans.maxOf { it.expiry ?: Instant.MIN }
+            val mappedBans = bans.map { it.expiry ?: Instant.MIN }
+            return bans[mappedBans.indexOf(highestExpiry)]
+        }
+
+        fun getActiveBans(uuid: UUID): List<Ban> {
+            val db = getInstance().dbConnection
+
+            return transaction (db) {
+                val bans = Ban.find { Bans.uuid eq uuid.toString() }
+                val list = ArrayList<Ban>()
+
+                bans.forEach { ban ->
+                    if (ban.expiry is Instant) {
+                        val expiry = ban.expiry as Instant
+                        if (expiry.isBefore(Instant.now()) && ban.active) {
+                            ban.active = false
+                        } else if (expiry.isAfter(Instant.now()) && ban.active) {
+                            list.add(ban)
+                        }
+                    } else if (ban.active) {
+                        list.add(ban)
+                    }
+                }
+                return@transaction list
+            }
+        }
+
+        fun getBan(banID: Int): Ban? {
+            val db = getInstance().dbConnection
+
+            return transaction (db) {
+                try {
+                    return@transaction Ban.find { Bans.id eq banID }.first()
+                } catch (e: NoSuchElementException) {
+                    return@transaction null
+                }
+            }
+        }
+
+        fun hasActiveBan(uuid: UUID): Boolean {
+            val db = getInstance().dbConnection
+
+            return transaction (db) {
+                val bans = Ban.find { Bans.uuid eq uuid.toString() }
+                bans.forEach { ban ->
+                    if (ban.expiry is Instant) {
+                        val expiry = ban.expiry as Instant
+                        if (expiry.isBefore(Instant.now()) && ban.active) {
+                            Bans.update({ Bans.id eq ban.id}) {
+                                it[active] = false
+                            }
+                        } else if (expiry.isAfter(Instant.now()) && ban.active) {
+                            return@transaction true
+                        }
+                    } else if (ban.active) {
+                        return@transaction true
+                    }
+                }
+                return@transaction false
+            }
+        }
+
+        fun unBan(uuid: UUID) {
+            val db = getInstance().dbConnection
+
+            transaction (db) {
+                Ban.find { Bans.uuid eq uuid.toString() }.forEach {
+                    it.active = false
+                }
+            }
+        }
+
+        fun unBan(banID: Int) {
+            val db = getInstance().dbConnection
+
+            transaction (db) {
+                Ban.find { Bans.id eq banID }.forEach {
+                    it.active = false
+                }
+            }
+        }
+    }
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/db/Bans.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/db/Bans.kt
@@ -16,6 +16,7 @@ object Bans: IntIdTable() {
     val uuid: Column<String> = char("uuid", 36)
     val moderator: Column<String> = char("moderator", 36)
     val permanent = bool("permanent")
+    val bannedAt = timestamp("bannedAt")
     val expiry = timestamp("expiry").nullable()
     val reason = text("reason").nullable()
     val active = bool("active").default(true)
@@ -26,6 +27,7 @@ class Ban(id: EntityID<Int>): IntEntity(id) {
     var uuid by Bans.uuid
     var moderator by Bans.moderator
     var permanent by Bans.permanent
+    var bannedAt by Bans.bannedAt
     var expiry by Bans.expiry
     var reason by Bans.reason
     var active by Bans.active
@@ -47,6 +49,7 @@ class BanUtils {
                     uuid = playerUUID
                     moderator = moderatorUUID
                     permanent = isPermanent
+                    bannedAt = Instant.now()
                     reason = banReason
                     expiry = banExpiry
                     active = true

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/events/Events.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/events/Events.kt
@@ -4,13 +4,12 @@ import com.velocitypowered.api.event.PostOrder
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.player.ServerPreConnectEvent
 import me.ixhbinphoenix.smPl.smProxy.db.BanUtils
-import me.ixhbinphoenix.smPl.smProxy.db.Bans
 import me.ixhbinphoenix.smPl.smProxy.getInstance
 import me.ixhbinphoenix.smPl.smProxy.utils.GroupRanks
 import me.ixhbinphoenix.smPl.smProxy.utils.getPermanentBanMessage
 import me.ixhbinphoenix.smPl.smProxy.utils.getPlayerRank
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.NamedTextColor
+import me.ixhbinphoenix.smPl.smProxy.utils.getTemporaryBanMessage
+import java.time.Instant
 
 class Events {
   private val instance = getInstance()
@@ -23,7 +22,7 @@ class Events {
       if (ban.permanent) {
         event.player.disconnect(getPermanentBanMessage(ban.reason ?: "No Reason specified", ban.id.value))
       } else {
-        event.player.disconnect(Component.text("Ban Messages for temporary bans have not yet been implemented!").color(NamedTextColor.RED))
+        event.player.disconnect(getTemporaryBanMessage(ban.reason ?: "No Reason specified", ban.id.value, (ban.expiry?.toEpochMilli()?: Instant.now().toEpochMilli()) - Instant.now().toEpochMilli()))
       }
     }
     if (event.originalServer.serverInfo.name == "build") {

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/events/Events.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/events/Events.kt
@@ -2,22 +2,30 @@ package me.ixhbinphoenix.smPl.smProxy.events
 
 import com.velocitypowered.api.event.PostOrder
 import com.velocitypowered.api.event.Subscribe
-import com.velocitypowered.api.event.player.KickedFromServerEvent
-import com.velocitypowered.api.event.player.PlayerChatEvent
 import com.velocitypowered.api.event.player.ServerPreConnectEvent
+import me.ixhbinphoenix.smPl.smProxy.db.BanUtils
+import me.ixhbinphoenix.smPl.smProxy.db.Bans
 import me.ixhbinphoenix.smPl.smProxy.getInstance
 import me.ixhbinphoenix.smPl.smProxy.utils.GroupRanks
+import me.ixhbinphoenix.smPl.smProxy.utils.getPermanentBanMessage
 import me.ixhbinphoenix.smPl.smProxy.utils.getPlayerRank
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 
 class Events {
   private val instance = getInstance()
-  private val server = instance.server
-  private val logger = instance.logger
 
-  @Subscribe(order = PostOrder.EARLY)
+  @Subscribe(order = PostOrder.FIRST)
   fun onPlayerLogin(event: ServerPreConnectEvent) {
+    instance.uuidCache.addPlayer(event.player)
+    if (BanUtils.hasActiveBan(event.player.uniqueId)) {
+      val ban = BanUtils.getSeverestBan(BanUtils.getActiveBans(event.player.uniqueId))
+      if (ban.permanent) {
+        event.player.disconnect(getPermanentBanMessage(ban.reason ?: "No Reason specified", ban.id.value))
+      } else {
+        event.player.disconnect(Component.text("Ban Messages for temporary bans have not yet been implemented!").color(NamedTextColor.RED))
+      }
+    }
     if (event.originalServer.serverInfo.name == "build") {
       if (getPlayerRank(event.player).rank != GroupRanks.TEAM) {
         event.result = ServerPreConnectEvent.ServerResult.denied()

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/smProxy.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/smProxy.kt
@@ -5,16 +5,32 @@ import com.velocitypowered.api.event.PostOrder
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent
 import com.velocitypowered.api.plugin.Plugin
+import com.velocitypowered.api.plugin.annotation.DataDirectory
 import com.velocitypowered.api.proxy.ProxyServer
-import me.ixhbinphoenix.smPl.smProxy.commands.broadcastCommand
-import me.ixhbinphoenix.smPl.smProxy.commands.pingCommand
-import me.ixhbinphoenix.smPl.smProxy.commands.scCommand
+import kotlinx.serialization.ExperimentalSerializationApi
+import me.ixhbinphoenix.smPl.smProxy.commands.*
 import me.ixhbinphoenix.smPl.smProxy.events.Events
+import me.ixhbinphoenix.smPl.smProxy.uuid.UUIDCache
+import org.jetbrains.exposed.sql.Database
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 import org.slf4j.Logger
+import java.io.File
+import java.io.IOException
+import java.nio.file.Path
+
+@Serializable
+data class PluginConfig(val jdbcConnectionString: String, val postgresUser: String, val postgresPassword: String)
 
 @Suppress("unused", "ClassName")
 @Plugin(id = "smproxy", name = "smProxy", version = "0.0.2", url = "https://github.com/ixhbinphoenix/smPl", description = "Stahlmetall plugins", authors = ["ixhbinphoenix", "renkertm"])
-class smProxy @Inject constructor(val server: ProxyServer, val logger: Logger) {
+class smProxy @Inject constructor(val server: ProxyServer, val logger: Logger, @DataDirectory val folder: Path) {
+
+  val pluginConfig = loadConfig()
+  val dbConnection: Database = loadDatabase()
+  val uuidCache = UUIDCache()
 
   init {
     instance = this
@@ -24,11 +40,44 @@ class smProxy @Inject constructor(val server: ProxyServer, val logger: Logger) {
   fun onInit(event: ProxyInitializeEvent) {
     server.eventManager.register(this, Events())
 
-    server.commandManager.register(scCommand().meta, scCommand())
-    server.commandManager.register(broadcastCommand().meta, broadcastCommand())
-    server.commandManager.register(pingCommand().meta, pingCommand())
+    server.commandManager.register("sc", scCommand())
+    server.commandManager.register("broadcast", broadcastCommand(), "bc")
+    server.commandManager.register("ping", pingCommand())
+    server.commandManager.register("ban", banCommand())
+    server.commandManager.register("unban", unbanCommand())
 
     logger.info("smProxy enabled")
+  }
+
+  @OptIn(ExperimentalSerializationApi::class)
+  private fun loadConfig(): PluginConfig {
+    val configFile = File(folder.toFile(), "config.json")
+    if (!configFile.parentFile.exists()) {
+      configFile.parentFile.mkdirs()
+    }
+
+    return if (!configFile.exists()) {
+      try {
+        val config = PluginConfig("", "root", "root")
+        val emptyConfig = Json.encodeToString(config)
+        configFile.createNewFile()
+        configFile.writeText(emptyConfig)
+        config
+      } catch (e: IOException) {
+        e.printStackTrace()
+        PluginConfig("", "root", "root")
+      }
+    } else {
+      Json.decodeFromStream(configFile.inputStream())
+    }
+  }
+
+  private fun loadDatabase(): Database {
+    return if (pluginConfig.jdbcConnectionString == "") {
+      Database.connect("jdbc:postgresql://localhost:5432/minecraft", driver = "org.postgresql.Driver", user = pluginConfig.postgresUser, password = pluginConfig.postgresPassword)
+    } else {
+      Database.connect(pluginConfig.jdbcConnectionString, driver = "org.postgresql.Driver", user = pluginConfig.postgresUser, password = pluginConfig.postgresPassword)
+    }
   }
 
   companion object {

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/utils/Components.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/utils/Components.kt
@@ -1,0 +1,14 @@
+package me.ixhbinphoenix.smPl.smProxy.utils
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+
+fun getPermanentBanMessage(reason: String, banID: Int): Component {
+    return Component.text("You have been permanently banned from the Network!\n").color(NamedTextColor.RED)
+        .append(Component.text("Reason: ").color(NamedTextColor.RED)
+            .append(Component.text("$reason\n").color(NamedTextColor.YELLOW))
+        )
+        .append(Component.text("Ban ID: ").color(NamedTextColor.RED)
+            .append(Component.text("#$banID").color(NamedTextColor.YELLOW))
+        )
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/utils/Components.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/utils/Components.kt
@@ -12,3 +12,16 @@ fun getPermanentBanMessage(reason: String, banID: Int): Component {
             .append(Component.text("#$banID").color(NamedTextColor.YELLOW))
         )
 }
+
+fun getTemporaryBanMessage(reason: String, banID: Int, duration: Long): Component {
+    return Component.text("You have been temporarily banned from the Network!\n").color(NamedTextColor.RED)
+        .append(Component.text("Reason: ").color(NamedTextColor.RED)
+            .append(Component.text("$reason\n").color(NamedTextColor.YELLOW))
+        )
+        .append(Component.text("Remaining Time: ").color(NamedTextColor.RED)
+            .append(Component.text("${TimeUtils.timeString(duration)}\n").color(NamedTextColor.YELLOW))
+        )
+        .append(Component.text("Ban ID: ").color(NamedTextColor.RED)
+            .append(Component.text("#$banID").color(NamedTextColor.YELLOW))
+        )
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/utils/TimeUtils.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/utils/TimeUtils.kt
@@ -1,0 +1,84 @@
+package me.ixhbinphoenix.smPl.smProxy.utils
+
+import kotlin.math.absoluteValue
+import kotlin.math.roundToLong
+
+// This class is heavily inspired by ms from Vercel (https://github.com/vercel/ms)
+// ms is licensed under the MIT License
+class TimeUtils {
+    companion object {
+        fun parseString(str: String): Long? {
+            val s = 1000
+            val m = s * 60
+            val h = m * 60
+            val d = h * 2
+            val w = d * 7
+            val y = w * 365.25
+
+            val reg = Regex("^(-?(?:\\d+)?\\.?\\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?\$", RegexOption.IGNORE_CASE)
+            val groups = reg.findAll(str).toList().map { it.groups }.first()
+            val n = groups[1]!!.value.toFloat()
+            return when (groups[2]!!.value.lowercase()) {
+                "years", "year", "yrs", "yr", "y" -> {
+                    (n * y).roundToLong()
+                }
+                "weeks", "week", "w" -> {
+                    (n * w).roundToLong()
+                }
+                "days", "day", "d" -> {
+                    (n * d).roundToLong()
+                }
+                "hours", "hour", "hrs", "hr", "h" -> {
+                    (n * h).roundToLong()
+                }
+                "minutes", "minute", "mins", "min", "m" -> {
+                    (n * m).roundToLong()
+                }
+                "seconds", "second", "secs", "sec", "s" -> {
+                    (n * s).roundToLong()
+                }
+                "milliseconds", "millisecond", "msecs", "msec", "ms" -> {
+                    n.roundToLong()
+                }
+                else -> {
+                    null
+                }
+            }
+        }
+
+
+        fun timeString(time: Long): String {
+            val s = 1000
+            val m = s * 60
+            val h = m * 60
+            val d = h * 2
+            val w = d * 7
+            val y = w * 365.25
+
+            val ms = time.absoluteValue
+            return when {
+                ms >= y -> {
+                    "${time / y}y"
+                }
+                ms >= w -> {
+                    "${time / w}w"
+                }
+                ms >= d -> {
+                    "${time / d}d"
+                }
+                ms >= h -> {
+                    "${time / h}h"
+                }
+                ms >= m -> {
+                    "${time / m}m"
+                }
+                ms >= s -> {
+                    "${time / s}s"
+                }
+                else -> {
+                    "${time}ms"
+                }
+            }
+        }
+    }
+}

--- a/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/uuid/UUIDCache.kt
+++ b/smProxy/src/main/kotlin/me/ixhbinphoenix/smPl/smProxy/uuid/UUIDCache.kt
@@ -1,0 +1,88 @@
+package me.ixhbinphoenix.smPl.smProxy.uuid
+
+import com.velocitypowered.api.proxy.Player
+import com.velocitypowered.api.util.UuidUtils
+import kotlinx.serialization.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import java.net.URL
+import java.time.Instant
+import java.util.*
+import kotlin.collections.HashMap
+
+@Serializable
+data class UUIDResponse(val name: String, val id: String)
+
+@Serializable
+data class Name(val name: String, val changedToAt: Long)
+
+@Suppress("OPT_IN_IS_NOT_ENABLED")
+@OptIn(ExperimentalSerializationApi::class)
+class UUIDCache {
+
+    private val uuidURL = "https://api.mojang.com/users/profiles/minecraft/%s?at=%d"
+    private val nameURL = "https://api.mojang.com/user/profile/%s/names"
+
+    private val uuidCache = HashMap<String, UUID>()
+    private val nameCache = HashMap<UUID, String>()
+
+    /**
+     * Gets UUID from player name if the player exists, either from cache or from the API
+     * @param name Name of the player
+     * @return UUID of the player
+     */
+    @Suppress("unused")
+    fun getUUIDIfExists(name: String): UUID? {
+        return if (uuidCache.containsKey(name)) {
+            uuidCache[name]!!
+        } else {
+            fetchUUIDIfExists(name)
+        }
+    }
+
+
+    private fun fetchUUIDIfExists(name: String, timestamp: Instant = Instant.now()): UUID? {
+        val connection = URL(String.format(uuidURL, name.lowercase(), timestamp.epochSecond * 1000)).openConnection()
+        connection.readTimeout = 5000
+        return try {
+            val uuid = UuidUtils.fromUndashed(Json.decodeFromStream<UUIDResponse>(connection.getInputStream()).id)
+            uuidCache[name.lowercase()] = uuid
+            nameCache[uuid] = name.lowercase()
+            uuid
+        } catch (e: SerializationException) {
+            null
+        }
+    }
+
+    /**
+     * Gets the player name from a UUID, either from cache or from the API
+     * @param uuid The UUID of the player
+     * @return The name of the player
+     */
+    @Suppress("unused")
+    fun getName(uuid: UUID): String {
+        // If someone has somehow obtained a UUID, we can be pretty sure that the player exists
+        return if (nameCache.containsKey(uuid)) {
+            nameCache[uuid]!!
+        } else {
+            fetchName(uuid)
+        }
+    }
+
+    private fun fetchName(uuid: UUID): String {
+        val connection = URL(String.format(nameURL, UuidUtils.toUndashed(uuid))).openConnection()
+        connection.readTimeout = 5000
+        val nameResponse: List<Name> = Json.decodeFromStream(connection.getInputStream())
+        val name = nameResponse.last().name.lowercase()
+        uuidCache[name] = uuid
+        nameCache[uuid] = name
+        return name
+    }
+
+    fun addPlayer(player: Player) {
+        val name = player.username.lowercase()
+        val uuid = player.uniqueId
+        uuidCache[name] = uuid
+        nameCache[uuid] = name
+    }
+}


### PR DESCRIPTION
Closes #14 

Adds Ban system, including temporary bans.
Format for ban command is the following: /ban player [time] reason
Time needs to be a single combined string, like this: "3d". Important: m is not months, it's minutes

Also adds SQL Connectivity for smItems. smItems now loads all items for /giveitem and the tab completion for /giveitem from a PostgreSQL db. The configuration for the database is in the config.yml of the plugin.